### PR TITLE
remove `.gitattributes` and `composer.json` from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 /.wordpress-org export-ignore
 /.github export-ignore
 
+/.gitattributes export-ignore
+/composer.json export-ignore
 /LICENSE export-ignore
 /README.md export-ignore


### PR DESCRIPTION
This PR adds `.gitattributes` and `composer.json` as `export-ignore` in `.gitattributes` so they do not get deployed to WP.org in subsequent plugin releases.