### PR TITLE
fix branch on `actions/checkout` reference

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@stable
       env:


### PR DESCRIPTION
Note that https://github.com/actions/checkout now uses `main` instead of `master` (though you could also reference `actions/checkout@v2` if you wanted to limit future updates to v3 without first knowingly applying that change, but since you already were riding on `master` it seemed correct to replace that with `main`.